### PR TITLE
feat: implement direct release workflow for master branch

### DIFF
--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -1,28 +1,22 @@
 # Release Process
 
-This repository uses an automated release process that works with protected branches by creating pull requests instead of pushing directly to the main branch.
+This repository uses an automated release process that creates tagged releases directly when commits are pushed to the master branch.
 
 ## How It Works
 
 ### 1. Automatic Release Detection
 When commits are pushed to the `master` or `main` branch, the release workflow automatically:
 - Analyzes commit messages to determine the next version (semantic versioning)
-- Creates a new release branch (`release/vX.Y.Z`)
 - Updates the version in `build.zig.zon`
-- Creates a pull request to merge the release into the main branch
+- Creates a Git tag for the release
+- Creates a GitHub release with the new version
 
-### 2. Release Branch Workflow
-The `release-branch.yml` workflow:
+### 2. Direct Release Workflow
+The `release-on-master.yml` workflow:
 - **Triggers**: On push to `master`/`main` branches
-- **Creates**: A new release branch with version bump
-- **Opens**: A pull request for the release
-- **Waits**: For the PR to be merged
-
-### 3. Release Creation
-The `release-on-pr-merge.yml` workflow:
-- **Triggers**: When a release PR is merged
+- **Updates**: Version in `build.zig.zon`
 - **Creates**: Git tag and GitHub release
-- **Cleans up**: The release branch
+- **Pushes**: Version bump commit back to master
 
 ## Semantic Versioning
 
@@ -43,18 +37,18 @@ release: minor
 ## Release Process Steps
 
 1. **Push commits** to `master`/`main` branch
-2. **Workflow triggers** and creates release branch
-3. **Review the PR** that was created
-4. **Merge the PR** to trigger the release
-5. **Release is created** automatically with tag and GitHub release
+2. **Workflow triggers** and analyzes commits
+3. **Version is determined** using semantic versioning
+4. **Release is created** automatically with tag and GitHub release
+5. **Version bump** is committed back to master
 
 ## Benefits
 
-- ✅ **Works with protected branches** - No direct pushes required
-- ✅ **Reviewable releases** - All releases go through PR review
-- ✅ **Automatic cleanup** - Release branches are deleted after merge
+- ✅ **Simple and direct** - No complex branch management
+- ✅ **Automatic releases** - Creates releases on every master push
 - ✅ **Semantic versioning** - Automatic version detection
 - ✅ **Manual override** - Can specify version bump level
+- ✅ **Immediate releases** - No waiting for PR reviews
 
 ## Troubleshooting
 
@@ -76,6 +70,7 @@ To create a manual release:
 
 ## Workflow Files
 
-- `release-branch.yml` - Creates release branches and PRs
-- `release-on-pr-merge.yml` - Creates releases when PRs are merged
-- `release-on-merge.yml` - **DEPRECATED** - Old workflow that pushed directly
+- `release-on-master.yml` - **ACTIVE** - Creates releases directly on master branch updates
+- `release-branch.yml` - **DEPRECATED** - Old branch-based workflow
+- `release-on-pr-merge.yml` - **DEPRECATED** - Old PR-based workflow
+- `release-on-merge.yml` - **DEPRECATED** - Old direct push workflow

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,11 +1,14 @@
-name: Release Branch Workflow
+name: Release Branch Workflow - DEPRECATED
 
+# This workflow is deprecated in favor of release-on-master.yml
+# which creates releases directly on master branch updates
 on:
-  push:
-    branches:
-      - master
-      - main
-  workflow_dispatch: # Allow manual triggering
+  # Disabled - use release-on-master.yml instead
+  # push:
+  #   branches:
+  #     - master
+  #     - main
+  workflow_dispatch: # Keep for manual triggering if needed
 
 jobs:
   create-release-branch:

--- a/.github/workflows/release-on-master.yml
+++ b/.github/workflows/release-on-master.yml
@@ -1,0 +1,171 @@
+name: Release on Master Branch
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  release:
+    name: Create Tagged Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.14.1
+
+      - name: Determine previous tag
+        id: prev
+        run: |
+          set -euo pipefail
+          if git describe --tags --abbrev=0 >/dev/null 2>&1; then
+            PREV_TAG=$(git describe --tags --abbrev=0)
+          else
+            PREV_TAG="0.0.0"
+          fi
+          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "Previous tag: $PREV_TAG"
+
+      - name: Compute next version (semantic)
+        id: next
+        run: |
+          set -euo pipefail
+          PREV_TAG="${{ steps.prev.outputs.prev_tag }}"
+          RANGE="${PREV_TAG}..HEAD"
+          if [ "$PREV_TAG" = "0.0.0" ]; then RANGE=""; fi
+
+          COMMITS=$(git log --format=%s ${RANGE})
+
+          LEVEL="patch"
+          if echo "$COMMITS" | grep -E "^feat!|BREAKING CHANGE" >/dev/null; then
+            LEVEL="major"
+          elif echo "$COMMITS" | grep -E "^feat\b" >/dev/null; then
+            LEVEL="minor"
+          elif echo "$COMMITS" | grep -E "^fix\b|^perf\b|^refactor\b|^chore\b|^build\b|^ci\b|^docs\b|^style\b|^test\b" >/dev/null; then
+            LEVEL="patch"
+          fi
+
+          # Allow manual override via commit footer 'release: major|minor|patch'
+          if echo "$COMMITS" | grep -E "release: (major|minor|patch)" >/dev/null; then
+            LEVEL=$(echo "$COMMITS" | grep -Eo "release: (major|minor|patch)" | tail -n1 | awk '{print $2}')
+          fi
+
+          MAJOR=$(echo "$PREV_TAG" | cut -d. -f1)
+          MINOR=$(echo "$PREV_TAG" | cut -d. -f2)
+          PATCH=$(echo "$PREV_TAG" | cut -d. -f3)
+
+          case "$LEVEL" in
+            major)
+              MAJOR=$((MAJOR+1)); MINOR=0; PATCH=0 ;;
+            minor)
+              MINOR=$((MINOR+1)); PATCH=0 ;;
+            patch)
+              PATCH=$((PATCH+1)) ;;
+          esac
+
+          NEXT_TAG="${MAJOR}.${MINOR}.${PATCH}"
+          echo "level=$LEVEL" >> $GITHUB_OUTPUT
+          echo "next_tag=$NEXT_TAG" >> $GITHUB_OUTPUT
+          echo "Next version: $NEXT_TAG ($LEVEL)"
+
+      - name: Check if release is needed
+        id: check
+        run: |
+          set -euo pipefail
+          PREV_TAG="${{ steps.prev.outputs.prev_tag }}"
+          NEXT_TAG="${{ steps.next.outputs.next_tag }}"
+          
+          if [ "$PREV_TAG" = "$NEXT_TAG" ]; then
+            echo "No new commits since last release, skipping"
+            echo "needs_release=false" >> $GITHUB_OUTPUT
+          else
+            echo "New release needed: $PREV_TAG -> $NEXT_TAG"
+            echo "needs_release=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update build.zig.zon version
+        if: steps.check.outputs.needs_release == 'true'
+        run: |
+          set -euo pipefail
+          NEXT_TAG="${{ steps.next.outputs.next_tag }}"
+          sed -E -i "s/(\\.version = \"[0-9]+\\.[0-9]+\\.[0-9]+\")/\.version = \"${NEXT_TAG}\"/" build.zig.zon
+          echo "Updated build.zig.zon to version ${NEXT_TAG}"
+          git diff -- build.zig.zon || true
+
+      - name: Commit version bump
+        if: steps.check.outputs.needs_release == 'true'
+        run: |
+          set -euo pipefail
+          NEXT_TAG="${{ steps.next.outputs.next_tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add build.zig.zon
+          git commit -m "chore(release): v${NEXT_TAG}" || echo "No changes to commit"
+
+      - name: Create and push tag
+        if: steps.check.outputs.needs_release == 'true'
+        run: |
+          set -euo pipefail
+          NEXT_TAG="${{ steps.next.outputs.next_tag }}"
+          
+          # Create and push tag
+          git tag -a "v${NEXT_TAG}" -m "Release v${NEXT_TAG}" || echo "Tag exists"
+          git push origin "v${NEXT_TAG}" || echo "Tag already pushed"
+
+      - name: Push version bump commit
+        if: steps.check.outputs.needs_release == 'true'
+        run: |
+          set -euo pipefail
+          git push origin HEAD || echo "No changes to push"
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.needs_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.next.outputs.next_tag }}
+          name: hash-zig v${{ steps.next.outputs.next_tag }}
+          body: |
+            ## Release v${{ steps.next.outputs.next_tag }}
+            
+            Automated release for hash-zig.
+            
+            **Version:** v${{ steps.next.outputs.next_tag }}
+            **Bump level:** ${{ steps.next.outputs.level }}
+            
+            ### Changes
+            This release includes all commits since the previous release.
+            
+            ### Installation
+            ```zig
+            .{
+                .name = .my_project,
+                .version = "0.1.0",
+                .dependencies = .{
+                    .@"hash-zig" = .{
+                        .url = "https://github.com/ch4r10t33r/hash-zig/archive/refs/tags/v${{ steps.next.outputs.next_tag }}.tar.gz",
+                        .hash = "1220...", // Will be generated by zig build
+                    },
+                },
+            }
+            ```
+            
+            ### What's New
+            - Hypercube parameters: 64 chains of length 8 (w=3)
+            - Rust-compatible Poseidon2: width=16, external_rounds=8, internal_rounds=20, sbox_degree=3
+            - SIMD optimizations for improved performance
+            - Multiple implementation options (Optimized V2 and SIMD)
+          draft: false
+          prerelease: false

--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -1,11 +1,15 @@
-name: Release on PR Merge
+name: Release on PR Merge - DEPRECATED
 
+# This workflow is deprecated in favor of release-on-master.yml
+# which creates releases directly on master branch updates
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - master
-      - main
+  # Disabled - use release-on-master.yml instead
+  # pull_request:
+  #   types: [closed]
+  #   branches:
+  #     - master
+  #     - main
+  workflow_dispatch: # Keep for manual triggering if needed
 
 jobs:
   release:


### PR DESCRIPTION
- Add release-on-master.yml workflow for direct releases on master updates
- Deprecate complex branch-based workflows (release-branch.yml, release-on-pr-merge.yml)
- Update RELEASE_PROCESS.md documentation for simplified workflow
- Creates tagged releases directly when commits are pushed to master
- Includes semantic versioning and automatic GitHub release creation